### PR TITLE
feat: AdvertiserAction → ClickHouse

### DIFF
--- a/CMS/Plugin/exec/DACSConf.sh
+++ b/CMS/Plugin/exec/DACSConf.sh
@@ -81,6 +81,11 @@ cp $EXEC/rsync_immutable.sh $OUT_DIR/../rsync_immutable.sh
 
 let "EXIT_CODE|=$?"
 
+cp $EXEC/synclogs_rsync_adv_action_ch.sh $OUT_DIR/../synclogs_rsync_adv_action_ch.sh
+chmod +x $OUT_DIR/../synclogs_rsync_adv_action_ch.sh
+
+let "EXIT_CODE|=$?"
+
 $EXEC/ProcessHostFiles.sh \
   --plugin-root $PLUGIN_ROOT \
   --app-xml $APP_XML \

--- a/CMS/Plugin/exec/synclogs_rsync_adv_action_ch.sh
+++ b/CMS/Plugin/exec/synclogs_rsync_adv_action_ch.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# SyncLogs helper: primary rsync must succeed; optional ClickHouse inbox
+# side-copy is best-effort and must not fail the primary route.
+#
+# USAGE:
+#   synclogs_rsync_adv_action_ch.sh <SRC_PATH> <PRIMARY_DST> [CH_DST_DIR]
+#
+set -euo pipefail
+
+if [ "$#" -lt 2 ]; then
+  echo "USAGE: synclogs_rsync_adv_action_ch.sh <SRC_PATH> <PRIMARY_DST> [CH_DST_DIR]" >&2
+  exit 1
+fi
+
+SRC_PATH=$1
+PRIMARY_DST=$2
+CH_DST=${3:-}
+
+/usr/bin/rsync -t -z --timeout=55 --log-format=%f "$SRC_PATH" "$PRIMARY_DST"
+PRIMARY_RC=$?
+if [ "$PRIMARY_RC" -ne 0 ]; then
+  exit "$PRIMARY_RC"
+fi
+
+if [ -n "$CH_DST" ]; then
+  # Never fail SyncLogs / RIM delivery because of the analytics side-copy.
+  /usr/bin/rsync -t -z --timeout=55 --log-format=%f "$SRC_PATH" "$CH_DST" || true
+fi
+
+exit 0

--- a/CMS/Plugin/xslt/LogProcessing/ClickhouseUploader.xsl
+++ b/CMS/Plugin/xslt/LogProcessing/ClickhouseUploader.xsl
@@ -50,7 +50,8 @@
   "clickhouse_conn": "<xsl:value-of select="$clickhouse-conn"/>",
   "check_roots": [
     "<xsl:value-of select="concat($workspace-root, '/log/Predictor/ResearchLogs/ResearchImpression')"/>",
-    "<xsl:value-of select="concat($workspace-root, '/log/Predictor/ResearchLogs/ResearchClick')"/>"
+    "<xsl:value-of select="concat($workspace-root, '/log/Predictor/ResearchLogs/ResearchClick')"/>",
+    "<xsl:value-of select="concat($workspace-root, '/log/Predictor/ResearchLogs/AdvertiserAction')"/>"
   ],
   "error_root": "<xsl:value-of select="concat($workspace-root, '/log/ClickhouseUploader/Error')"/>",
   "batch": <xsl:value-of select="$batch"/>

--- a/CMS/Plugin/xslt/LogProcessing/SyncLogs.xsl
+++ b/CMS/Plugin/xslt/LogProcessing/SyncLogs.xsl
@@ -484,7 +484,6 @@
             <dir>Request</dir>
             <dir>Impression</dir>
             <dir>Click</dir>
-            <dir>AdvertiserAction</dir>
             <dir>PassbackOpportunity</dir>
             <dir>PassbackImpression</dir>
             <dir>TagRequest</dir>
@@ -680,6 +679,79 @@
             </cfg:hosts>
           </cfg:Route>
         </xsl:for-each>
+      </cfg:FeedRouteGroup>
+
+      <!--
+        AdvertiserAction is a separate FeedRouteGroup so we can dual-copy to
+        ClickHouseUploader inbox without touching the high-volume rsync path
+        used by Request/Impression/Click. Primary destination remains RIM.
+        Side-copy is best-effort (see synclogs_rsync_adv_action_ch.sh).
+      -->
+      <xsl:variable name="adv-action-ch-dst">
+        <xsl:if test="string-length($predictor-sync-logs-host) > 0">
+          <xsl:value-of select="concat(
+            ' rsync://',
+            $predictor-sync-logs-host, ':',
+            $predictor-sync-logs-port, '/',
+            $research-stat-receiver-path, '/AdvertiserAction/')"/>
+        </xsl:if>
+      </xsl:variable>
+
+      <xsl:variable name="adv-action-remote-copy-command">
+        <xsl:choose>
+          <xsl:when test="string-length($predictor-sync-logs-host) > 0">
+            <xsl:value-of select="concat(
+              $backup-command-prefix,
+              $colo-config-root, '/synclogs_rsync_adv_action_ch.sh ##SRC_PATH## rsync://##DST_HOST##:',
+              $remote-dest-port, '/ad-logs##DST_PATH##',
+              $adv-action-ch-dst,
+              $backup-command-postfix)"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="$remote-copy-command"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:variable>
+
+      <xsl:variable name="adv-action-local-copy-command">
+        <xsl:choose>
+          <xsl:when test="string-length($predictor-sync-logs-host) > 0">
+            <xsl:value-of select="concat(
+              $backup-command-prefix,
+              $colo-config-root, '/synclogs_rsync_adv_action_ch.sh ##SRC_PATH## ',
+              $log-files-root-dir, '##DST_PATH##',
+              $adv-action-ch-dst,
+              $backup-command-postfix)"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="$local-copy-command"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:variable>
+
+      <cfg:FeedRouteGroup
+        pool_threads="10"
+        local_copy_command_type="rsync"
+        remote_copy_command_type="rsync"
+        tries_per_file="2"
+        local_copy_command="{$adv-action-local-copy-command}"
+        remote_copy_command="{$adv-action-remote-copy-command}">
+
+        <xsl:variable name="advertiser-action-route">
+          <dirs>
+            <dir>AdvertiserAction</dir>
+          </dirs>
+        </xsl:variable>
+
+        <xsl:call-template name="Route">
+          <xsl:with-param name="type" select="'Hash'"/>
+          <xsl:with-param name="source-path-base" select="'CampaignManager/'"/>
+          <xsl:with-param name="destination-path-base" select="'/RequestInfoManager/In/'"/>
+          <xsl:with-param name="source-hosts" select="$campaign-manager-hosts"/>
+          <xsl:with-param name="destination-hosts" select="$request-info-manager-hosts"/>
+          <xsl:with-param name="dirs" select="$advertiser-action-route"/>
+          <xsl:with-param name="pattern" select="'.*\.##HASH##'"/>
+        </xsl:call-template>
       </cfg:FeedRouteGroup>
 
 

--- a/DACS/AdServer/LogProcessing/ClickhouseUploader.pm
+++ b/DACS/AdServer/LogProcessing/ClickhouseUploader.pm
@@ -14,6 +14,7 @@ sub start
   my $command =
     "mkdir -p \${workspace_root}/run && " .
     "mkdir -p \${workspace_root}/log/ClickhouseUploader/Error && " .
+    "mkdir -p \${workspace_root}/log/Predictor/ResearchLogs/AdvertiserAction && " .
     "if test -e $pid_file; then " .
       "pid=`cat $pid_file`; " .
       "kill -0 \$pid 2>/dev/null && exit 1 || rm -f $pid_file; " .

--- a/DACS/AdServer/Predictor/SyncLogsServer.pm
+++ b/DACS/AdServer/Predictor/SyncLogsServer.pm
@@ -16,6 +16,7 @@ sub start
     "mkdir -p \${log_root}/Predictor/ResearchLogs/ResearchImpression && " .
     "mkdir -p \${log_root}/Predictor/ResearchLogs/ResearchClick && " .
     "mkdir -p \${log_root}/Predictor/ResearchLogs/ResearchAction && " .
+    "mkdir -p \${log_root}/Predictor/ResearchLogs/AdvertiserAction && " .
     "mkdir -p \${log_root}/Predictor/ResearchLogs/ResearchWebStat && " .
     "mkdir -p \${log_root}/Predictor/ResearchLogs/ResearchProf && " .
     "mkdir -p \${log_root}/Predictor/ResearchLogs/BidCostStat && " .

--- a/bin/AdvertiserActionClickhouseAdapter.py
+++ b/bin/AdvertiserActionClickhouseAdapter.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Convert AdvertiserAction TSV log files to CSV for ClickHouse INSERT."""
+
+import argparse
+import csv
+import sys
+
+
+FIELDS = (
+  'time',
+  'user_id',
+  'request_id',
+  'action_id',
+  'device_channel_id',
+  'action_request_id',
+  'ccg_ids',
+  'referrer',
+  'order_id',
+  'ip',
+  'cur_value',
+)
+
+
+def strip_optional(value: str) -> str:
+  if value is None:
+    return ''
+  value = value.strip()
+  if value in ('', '-'):
+    return ''
+  if value.startswith('@'):
+    return value[1:]
+  return value
+
+
+def to_uint(value: str) -> str:
+  value = strip_optional(value)
+  if not value:
+    return '0'
+  return value
+
+
+def to_time(value: str) -> str:
+  value = strip_optional(value)
+  if not value:
+    return ''
+  # AdvertiserAction uses YYYY-MM-DD_HH:MM:SS
+  return value.replace('_', ' ', 1)
+
+
+def to_float(value: str) -> str:
+  value = strip_optional(value)
+  if not value:
+    return '0'
+  return value
+
+
+def convert_row(row):
+  if len(row) < 11:
+    return None
+  return [
+    to_time(row[0]),
+    strip_optional(row[1]),
+    strip_optional(row[2]),
+    to_uint(row[3]),
+    to_uint(row[4]),
+    strip_optional(row[5]),
+    strip_optional(row[6]),
+    strip_optional(row[7]),
+    strip_optional(row[8]),
+    strip_optional(row[9]),
+    to_float(row[10]),
+  ]
+
+
+def main():
+  parser = argparse.ArgumentParser(
+    description='Adapt AdvertiserAction TSV logs for ClickHouse CSVWithNames insert.')
+  parser.add_argument('filename', nargs='+')
+  args = parser.parse_args()
+
+  writer = csv.writer(sys.stdout, lineterminator='\n')
+  writer.writerow(FIELDS)
+
+  for read_file in args.filename:
+    with open(read_file, 'r', encoding='utf-8', errors='replace') as infile:
+      reader = csv.reader(infile, delimiter='\t')
+      try:
+        next(reader)  # skip "AdvertiserAction\t3.6"
+      except StopIteration:
+        continue
+      for row in reader:
+        if not row or (len(row) == 1 and not row[0].strip()):
+          continue
+        out = convert_row(row)
+        if out is not None:
+          writer.writerow(out)
+
+
+if __name__ == '__main__':
+  main()

--- a/bin/RImpressionStatUploader.py
+++ b/bin/RImpressionStatUploader.py
@@ -148,6 +148,46 @@ class RClickUploader(object) :
         ", command_line = '" + command_line + "'")
 
 
+"""
+AdvertiserActionUploader: upload pixel/action event logs to ClickHouse.
+Deletes source files only after successful INSERT (avoids disk backlog).
+"""
+class AdvertiserActionUploader(object) :
+  clickhouse_conn : str
+  command_line_templ : jinja2.Template
+  logger = None
+
+  def __init__(self, config, logger = None) :
+    self.clickhouse_conn = config.clickhouse_conn
+    self.command_line_templ = jinja2.Template(
+      "AdvertiserActionClickhouseAdapter.py {{ process_files|join(' ') }} | "
+      "clickhouse-client {{clickhouse_conn}} "
+      '--query="INSERT INTO AdvertiserAction FORMAT CSVWithNames"')
+    self.logger = logger
+
+  def process(self, process_files) :
+    command_line = self.command_line_templ.render({
+      'clickhouse_conn' : self.clickhouse_conn,
+      'process_files' : process_files
+    })
+    try :
+      self.logger.debug("To upload " + " ".join(process_files))
+      ret_code = os.system(command_line)
+      self.logger.debug("From upload " + " ".join(process_files) + ": " + str(ret_code))
+      if ret_code == 0 :
+        for process_file in process_files:
+          os.unlink(process_file)
+      else :
+        raise Exception(
+          "Error on upload " + " ".join(process_files) +
+          ": command_line = '" + command_line + "'")
+    except Exception as e :
+      self.logger.exception(
+        "Exception on upload " + " ".join(process_files) + ": " +
+        str(e) + ", command_line = '" + command_line + "'")
+      raise
+
+
 def check_stat_files(
     interrupter,
     config = None,
@@ -231,6 +271,7 @@ def main() :
   processors = {}
   processors['RImpression'] = RImpressionUploader(config, logger = logger)
   processors['RClick'] = RClickUploader(config, logger = logger)
+  processors['AdvertiserAction'] = AdvertiserActionUploader(config, logger = logger)
 
   with SignalInterruptHandler(
     [ signal.SIGINT, signal.SIGUSR1, signal.SIGHUP ],

--- a/docs/AdvertiserAction_ClickHouse_DEPLOY.md
+++ b/docs/AdvertiserAction_ClickHouse_DEPLOY.md
@@ -1,0 +1,169 @@
+# AdvertiserAction → ClickHouse: deploy guide
+
+Goal: stream `CampaignManager/Out/AdvertiserAction` into ClickHouse table `AdvertiserAction` **without** changing RIM / ActionStat / Postgres processing, with low load and no stuck-file backlog.
+
+This path **does not** store the full `/conv?...` URL (still not in the log). It does store `user_id`, `action_id`, referrer page, etc. for audience segments.
+
+## What the patch changes
+
+| File | Role |
+|---|---|
+| `bin/AdvertiserActionClickhouseAdapter.py` | TSV → CSV for CH |
+| `bin/RImpressionStatUploader.py` | processor `AdvertiserAction` + delete after OK |
+| `CMS/Plugin/xslt/LogProcessing/ClickhouseUploader.xsl` | watch `…/AdvertiserAction` |
+| `CMS/Plugin/xslt/LogProcessing/SyncLogs.xsl` | dedicated FeedRouteGroup for AdvAction; dual rsync |
+| `CMS/Plugin/exec/synclogs_rsync_adv_action_ch.sh` | primary rsync must succeed; CH copy `\|\| true` |
+| `CMS/Plugin/exec/DACSConf.sh` | install the shell helper next to `copy_and_backup.sh` |
+| `DACS/.../SyncLogsServer.pm` | `mkdir` inbox dir |
+| `DACS/.../ClickhouseUploader.pm` | `mkdir` inbox on uploader start |
+| `docs/sql/2026-08-03_advertiser_action_clickhouse.sql` | CH DDL + 180d TTL |
+
+### Why this does not break current processing
+
+1. **RIM still receives AdvertiserAction** via the same Hash route semantics (`CampaignManager/Out` → `RequestInfoManager/In/AdvertiserAction` + commit files).
+2. AdvertiserAction was **moved to its own FeedRouteGroup** so the dual-copy script is **not** on the Request/Impression/Click hot path (avoids bash overhead on high volume).
+3. Side-copy to ClickHouse is **best-effort**: failure does not fail primary rsync → SyncLogs still unlinks after RIM delivery as today.
+4. No C++ / CM / ActionFrontend changes.
+5. Uploader **deletes** files only after successful `INSERT` (same pattern as RImpression). Failures go to `ClickhouseUploader/Error`.
+
+## Prerequisites
+
+- Access to regenerate CMS configs (same flow you use for SyncLogs / ClickhouseUploader).
+- Deploy updated `bin/` scripts to hosts that run ClickhouseUploader (**adbe00**).
+- `clickhouse-client` on that host (already used for RImpression).
+- Ability to run one SQL on **click00**.
+- Restart SyncLogs (FE/CM hosts) and ClickhouseUploader (adbe00) after config roll-out.
+
+## Minimal prod sequence
+
+Do **not** reorder: CH table must exist before uploader starts consuming files.
+
+### 1. Merge / build / ship package
+
+Ship at least:
+
+- `bin/AdvertiserActionClickhouseAdapter.py` (executable bit)
+- `bin/RImpressionStatUploader.py`
+- `CMS/Plugin/exec/synclogs_rsync_adv_action_ch.sh` (via DACSConf → colo etc)
+- regenerated configs from updated XSL
+- updated DACS `.pm` if you restart services via DACS
+
+Usual path: merge MR → build → install server package on cluster hosts (same as other bin/ + CMS releases).
+
+### 2. Create ClickHouse table (once)
+
+From a host with `clickhouse-client` (e.g. postdb00):
+
+```bash
+clickhouse-client -h click00 --multiquery < docs/sql/2026-08-03_advertiser_action_clickhouse.sql
+```
+
+Verify:
+
+```bash
+clickhouse-client -h click00 --query "EXISTS TABLE default.AdvertiserAction"
+clickhouse-client -h click00 --query "SHOW CREATE TABLE default.AdvertiserAction"
+```
+
+### 3. Regenerate and roll SyncLogs + ClickhouseUploader configs
+
+Run your normal CMS/DACS config generation so that:
+
+- `$COLO/synclogs_rsync_adv_action_ch.sh` appears next to `copy_and_backup.sh`
+- each host `SyncLogsConfig.xml` has a **separate** FeedRouteGroup for AdvertiserAction whose `remote_copy_command` contains `synclogs_rsync_adv_action_ch.sh` and a `rsync://…/logs/AdvertiserAction/` target when predictor host is set
+- `ClickhouseUploaderConfig.json` `check_roots` includes  
+  `…/log/Predictor/ResearchLogs/AdvertiserAction`
+
+Sanity grep after generation (on generated tree, not prod yet):
+
+```bash
+grep -n 'synclogs_rsync_adv_action_ch\|AdvertiserAction' \
+  path/to/generated/*/SyncLogsConfig.xml \
+  path/to/generated/*/ClickhouseUploaderConfig.json
+```
+
+### 4. Ensure inbox directory on adbe00
+
+If SyncLogsServer / ClickhouseUploader will be restarted via DACS, mkdir is automatic.
+
+Otherwise once:
+
+```bash
+mkdir -p /opt/foros/server/var/log/Predictor/ResearchLogs/AdvertiserAction
+```
+
+(rsync module `logs` must map into `Predictor/ResearchLogs` as today for ResearchImpression.)
+
+### 5. Restart services (short window)
+
+Order:
+
+1. Deploy scripts + configs to hosts.
+2. Restart **ClickhouseUploader** on adbe00 (picks new check_roots + adapter).
+3. Restart **SyncLogs** on campaign-manager / FE hosts that emit AdvertiserAction (new FeedRouteGroup + helper script).
+
+Prefer your standard DACS/service restart wrappers. Keep the window short; RIM gap is the same class of risk as any SyncLogs restart.
+
+### 6. Verify (10–20 minutes)
+
+On a CM host (e.g. adfe101):
+
+```bash
+# primary path still moves files (directory often empty between flushes)
+ls -lt /opt/foros/server/var/log/CampaignManager/Out/AdvertiserAction | head
+```
+
+On adbe00 (or via `rsync://adbe00:10168/logs/AdvertiserAction/`):
+
+```bash
+# files should appear briefly, then disappear after upload
+ls -lt /opt/foros/server/var/log/Predictor/ResearchLogs/AdvertiserAction | head
+ls -lt /opt/foros/server/var/log/ClickhouseUploader/Error | head
+```
+
+ClickHouse:
+
+```bash
+clickhouse-client -h click00 --query "
+SELECT count(), min(time), max(time)
+FROM AdvertiserAction
+WHERE time > now() - INTERVAL 1 HOUR"
+```
+
+RIM / stats health (unchanged expectations):
+
+- `RequestInfoManager/In/AdvertiserAction` still receives traffic
+- no growth of stuck files in `CampaignManager/Out/AdvertiserAction`
+- ActionStat / Postgres action aggregates continue as before
+
+### 7. Disk guardrails
+
+- Table TTL = **180 days** (adjust in SQL if needed).
+- Uploader deletes inbox files after successful INSERT.
+- Watch `ClickhouseUploader/Error` — if non-empty, fix CH/adapter and clear/reprocess; do not leave forever.
+- Do **not** enable writing all pixels into `ResearchAction` (already has multi-month backlog).
+
+## Rollback
+
+1. Revert SyncLogs config to previous generation (or remove AdvAction FeedRouteGroup dual-copy and put `AdvertiserAction` back into the shared Hash route as before) → restart SyncLogs.
+2. Remove `AdvertiserAction` from ClickhouseUploader `check_roots` / revert uploader → restart ClickhouseUploader.
+3. Optional: `DROP TABLE AdvertiserAction` on click00.
+
+RIM processing returns to the pre-patch path; no CM rebuild required for rollback of the dual-copy alone.
+
+## Manual smoke test (optional, staging)
+
+```bash
+# adapter only
+AdvertiserActionClickhouseAdapter.py /path/to/AdvertiserAction.sample | head
+
+# full insert (staging)
+AdvertiserActionClickhouseAdapter.py /path/to/AdvertiserAction.sample \
+  | clickhouse-client -h click00 --query="INSERT INTO AdvertiserAction FORMAT CSVWithNames"
+```
+
+## Out of scope
+
+- Full HTTP GET / custom query params on `/conv`
+- Cleaning historical `ResearchAction` backlog on adbe00
+- Audience UI / export tooling on top of CH

--- a/docs/sql/2026-08-03_advertiser_action_clickhouse.sql
+++ b/docs/sql/2026-08-03_advertiser_action_clickhouse.sql
@@ -1,0 +1,22 @@
+-- ClickHouse DDL for pixel /conv event stream (AdvertiserAction logs).
+-- Apply on click00 (or the host from ClickhouseUploader clickhouse_conn).
+
+CREATE TABLE IF NOT EXISTS default.AdvertiserAction
+(
+    `time` DateTime('UTC'),
+    `user_id` String,
+    `request_id` String,
+    `action_id` UInt64,
+    `device_channel_id` UInt64,
+    `action_request_id` String,
+    `ccg_ids` String,
+    `referrer` String,
+    `order_id` String,
+    `ip` String,
+    `cur_value` Float64
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(time)
+ORDER BY (action_id, time, user_id)
+TTL time + toIntervalDay(180)
+SETTINGS index_granularity = 8192;


### PR DESCRIPTION
## Summary
- Stream `CampaignManager/Out/AdvertiserAction` into ClickHouse via a dedicated SyncLogs FeedRouteGroup (primary rsync to RIM unchanged; best-effort side-copy to ClickhouseUploader inbox).
- Add `AdvertiserActionClickhouseAdapter.py` + uploader processor; delete inbox files only after successful INSERT.
- Docs: deploy guide + ClickHouse DDL (180-day TTL).

## Test plan
- [ ] Apply DDL from `docs/sql/2026-08-03_advertiser_action_clickhouse.sql` on click00
- [ ] Regenerate CMS configs; confirm `synclogs_rsync_adv_action_ch.sh` is installed next to `copy_and_backup.sh`
- [ ] Confirm `ClickhouseUploaderConfig.json` includes `…/Predictor/ResearchLogs/AdvertiserAction`
- [ ] Restart ClickhouseUploader (adbe00), then SyncLogs on CM hosts
- [ ] Verify files appear briefly in AdvertiserAction inbox and are removed after upload
- [ ] `SELECT count(), min(time), max(time) FROM AdvertiserAction WHERE time > now() - INTERVAL 1 HOUR`
- [ ] Confirm RIM still receives `RequestInfoManager/In/AdvertiserAction` / ActionStat unaffected
- [ ] Watch `ClickhouseUploader/Error` stays empty

See `docs/AdvertiserAction_ClickHouse_DEPLOY.md` for full rollout/rollback.


Made with [Cursor](https://cursor.com)