### PR TITLE
feat: RAction → ClickHouse + fix Android OSVERSION regex

### DIFF
--- a/CMS/Plugin/exec/DACSConf.sh
+++ b/CMS/Plugin/exec/DACSConf.sh
@@ -81,6 +81,11 @@ cp $EXEC/rsync_immutable.sh $OUT_DIR/../rsync_immutable.sh
 
 let "EXIT_CODE|=$?"
 
+cp $EXEC/synclogs_rsync_side_copy.sh $OUT_DIR/../synclogs_rsync_side_copy.sh
+chmod +x $OUT_DIR/../synclogs_rsync_side_copy.sh
+
+let "EXIT_CODE|=$?"
+
 $EXEC/ProcessHostFiles.sh \
   --plugin-root $PLUGIN_ROOT \
   --app-xml $APP_XML \

--- a/CMS/Plugin/exec/synclogs_rsync_side_copy.sh
+++ b/CMS/Plugin/exec/synclogs_rsync_side_copy.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# SyncLogs helper: primary rsync must succeed; optional side-copy is
+# best-effort and must not fail the primary route (Predictor / RIM).
+#
+# USAGE:
+#   synclogs_rsync_side_copy.sh <SRC_PATH> <PRIMARY_DST> [SIDE_DST]
+#
+set -euo pipefail
+
+if [ "$#" -lt 2 ]; then
+  echo "USAGE: synclogs_rsync_side_copy.sh <SRC_PATH> <PRIMARY_DST> [SIDE_DST]" >&2
+  exit 1
+fi
+
+SRC_PATH=$1
+PRIMARY_DST=$2
+SIDE_DST=${3:-}
+
+/usr/bin/rsync -az -t --timeout=55 --log-format=%f "$SRC_PATH" "$PRIMARY_DST"
+PRIMARY_RC=$?
+if [ "$PRIMARY_RC" -ne 0 ]; then
+  exit "$PRIMARY_RC"
+fi
+
+if [ -n "$SIDE_DST" ]; then
+  /usr/bin/rsync -az -t --timeout=55 --log-format=%f "$SRC_PATH" "$SIDE_DST" || true
+fi
+
+exit 0

--- a/CMS/Plugin/xslt/LogProcessing/ClickhouseUploader.xsl
+++ b/CMS/Plugin/xslt/LogProcessing/ClickhouseUploader.xsl
@@ -50,7 +50,8 @@
   "clickhouse_conn": "<xsl:value-of select="$clickhouse-conn"/>",
   "check_roots": [
     "<xsl:value-of select="concat($workspace-root, '/log/Predictor/ResearchLogs/ResearchImpression')"/>",
-    "<xsl:value-of select="concat($workspace-root, '/log/Predictor/ResearchLogs/ResearchClick')"/>"
+    "<xsl:value-of select="concat($workspace-root, '/log/Predictor/ResearchLogs/ResearchClick')"/>",
+    "<xsl:value-of select="concat($workspace-root, '/log/Predictor/ResearchLogs/RActionClickhouse')"/>"
   ],
   "error_root": "<xsl:value-of select="concat($workspace-root, '/log/ClickhouseUploader/Error')"/>",
   "batch": <xsl:value-of select="$batch"/>

--- a/CMS/Plugin/xslt/LogProcessing/SyncLogs.xsl
+++ b/CMS/Plugin/xslt/LogProcessing/SyncLogs.xsl
@@ -986,10 +986,6 @@
               <xsl:attribute name="destination"><![CDATA[/]]>ResearchClick</xsl:attribute>
             </cfg:files>
             <cfg:files>
-              <xsl:attribute name="source">RequestInfoManager/Out/ResearchAction/RAction_*</xsl:attribute>
-              <xsl:attribute name="destination"><![CDATA[/]]>ResearchAction</xsl:attribute>
-            </cfg:files>
-            <cfg:files>
               <xsl:attribute name="source">RequestInfoManager/Out/BidCostStat/BidCostStat.2*</xsl:attribute>
               <xsl:attribute name="destination"><![CDATA[/]]>BidCostStat</xsl:attribute>
             </cfg:files>
@@ -1009,6 +1005,38 @@
             </cfg:files>
             <cfg:hosts destination="-non-used-hostname">
               <xsl:attribute name="source"><xsl:value-of select="$campaign-manager-hosts"/></xsl:attribute>
+            </cfg:hosts>
+          </cfg:Route>
+        </cfg:FeedRouteGroup>
+
+        <!--
+          RAction: keep Predictor inbox (ResearchAction) intact, and side-copy
+          into RActionClickhouse for ClickhouseUploader (delete-after-upload).
+          Pixels with action_id already reach ResearchActionLogger via
+          process_custom_action (RequestLogLoader) — no FE AdvertiserAction dual-copy.
+        -->
+        <cfg:FeedRouteGroup
+          local_copy_command="/bin/echo"
+          local_copy_command_type="rsync"
+          remote_copy_command_type="rsync"
+          tries_per_file="2">
+          <xsl:attribute name="remote_copy_command"><xsl:value-of
+            select="concat(
+              $colo-config-root,
+              '/synclogs_rsync_side_copy.sh ##SRC_PATH## rsync://',
+              $predictor-sync-logs-host, ':',
+              $predictor-sync-logs-port, '/',
+              $research-stat-receiver-path, '##DST_PATH## rsync://',
+              $predictor-sync-logs-host, ':',
+              $predictor-sync-logs-port, '/',
+              $research-stat-receiver-path, '/RActionClickhouse/')"/></xsl:attribute>
+          <cfg:Route type="RoundRobin">
+            <cfg:files>
+              <xsl:attribute name="source">RequestInfoManager/Out/ResearchAction/RAction_*</xsl:attribute>
+              <xsl:attribute name="destination"><![CDATA[/]]>ResearchAction</xsl:attribute>
+            </cfg:files>
+            <cfg:hosts destination="-non-used-hostname">
+              <xsl:attribute name="source"><xsl:value-of select="$request-info-manager-hosts"/></xsl:attribute>
             </cfg:hosts>
           </cfg:Route>
         </cfg:FeedRouteGroup>

--- a/DACS/AdServer/LogProcessing/ClickhouseUploader.pm
+++ b/DACS/AdServer/LogProcessing/ClickhouseUploader.pm
@@ -14,6 +14,7 @@ sub start
   my $command =
     "mkdir -p \${workspace_root}/run && " .
     "mkdir -p \${workspace_root}/log/ClickhouseUploader/Error && " .
+    "mkdir -p \${workspace_root}/log/Predictor/ResearchLogs/RActionClickhouse && " .
     "if test -e $pid_file; then " .
       "pid=`cat $pid_file`; " .
       "kill -0 \$pid 2>/dev/null && exit 1 || rm -f $pid_file; " .

--- a/DACS/AdServer/Predictor/SyncLogsServer.pm
+++ b/DACS/AdServer/Predictor/SyncLogsServer.pm
@@ -16,6 +16,7 @@ sub start
     "mkdir -p \${log_root}/Predictor/ResearchLogs/ResearchImpression && " .
     "mkdir -p \${log_root}/Predictor/ResearchLogs/ResearchClick && " .
     "mkdir -p \${log_root}/Predictor/ResearchLogs/ResearchAction && " .
+    "mkdir -p \${log_root}/Predictor/ResearchLogs/RActionClickhouse && " .
     "mkdir -p \${log_root}/Predictor/ResearchLogs/ResearchWebStat && " .
     "mkdir -p \${log_root}/Predictor/ResearchLogs/ResearchProf && " .
     "mkdir -p \${log_root}/Predictor/ResearchLogs/BidCostStat && " .

--- a/RequestInfoSvcs/RequestInfoManager/RequestOutLogger.cpp
+++ b/RequestInfoSvcs/RequestInfoManager/RequestOutLogger.cpp
@@ -2529,7 +2529,14 @@ namespace RequestInfoSvcs
     process_adv_action(
       const AdvActionInfo& /*adv_action_info*/)
       /*throw(AdvActionProcessor::Exception)*/
-    {}
+    {
+      // Intentionally empty.
+      // AdvertiserAction rows WITH action_id are dispatched as
+      // process_custom_action() from RequestLogLoader (full AdvExActionInfo),
+      // and those are written to RAction below.
+      // AdvActionInfo (no action_id) only has time/user_id/ccg_id — not enough
+      // for ResearchActionTraits CSV; leaving a stub avoids misleading partial rows.
+    }
 
     virtual void
     process_custom_action(

--- a/bin/RActionClickhouseAdapter.py
+++ b/bin/RActionClickhouseAdapter.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Convert RAction research CSV logs to ClickHouse CSVWithNames."""
+
+import argparse
+import csv
+import sys
+
+# ResearchActionTraits::csv_header()
+SRC_FIELDS = [
+  'Timestamp',
+  'Device',
+  'IP Address',
+  'UID',
+  'URL',
+  'Action ID',
+  'Order ID',
+  'Order Value',
+]
+
+OUT_FIELDS = [
+  'time',
+  'device_channel_id',
+  'ip',
+  'user_id',
+  'referrer',
+  'action_id',
+  'order_id',
+  'cur_value',
+]
+
+
+def norm(value: str) -> str:
+  if value is None:
+    return ''
+  value = value.strip()
+  if value in ('', '-'):
+    return ''
+  if value.startswith('@'):
+    return value[1:]
+  return value
+
+
+def to_uint(value: str) -> str:
+  value = norm(value)
+  return value if value else '0'
+
+
+def to_float(value: str) -> str:
+  value = norm(value)
+  return value if value else '0'
+
+
+def to_time(value: str) -> str:
+  value = norm(value)
+  if not value:
+    return ''
+  # accept both "YYYY-MM-DD HH:MM:SS" and "YYYY-MM-DD_HH:MM:SS"
+  return value.replace('_', ' ', 1)
+
+
+def convert_row(row_map):
+  return [
+    to_time(row_map.get('Timestamp', '')),
+    to_uint(row_map.get('Device', '')),
+    norm(row_map.get('IP Address', '')),
+    norm(row_map.get('UID', '')),
+    norm(row_map.get('URL', '')),
+    to_uint(row_map.get('Action ID', '')),
+    norm(row_map.get('Order ID', '')),
+    to_float(row_map.get('Order Value', '')),
+  ]
+
+
+def main():
+  parser = argparse.ArgumentParser(
+    description='Adapt RAction CSV logs for ClickHouse CSVWithNames insert.')
+  parser.add_argument('filename', nargs='+')
+  args = parser.parse_args()
+
+  writer = csv.writer(sys.stdout, lineterminator='\n')
+  writer.writerow(OUT_FIELDS)
+
+  for read_file in args.filename:
+    with open(read_file, 'r', encoding='utf-8', errors='replace') as infile:
+      reader = csv.DictReader(infile)
+      # tolerate header drift / missing names
+      if reader.fieldnames is None:
+        continue
+      for row in reader:
+        if not row:
+          continue
+        writer.writerow(convert_row(row))
+
+
+if __name__ == '__main__':
+  main()

--- a/bin/RImpressionStatUploader.py
+++ b/bin/RImpressionStatUploader.py
@@ -148,6 +148,46 @@ class RClickUploader(object) :
         ", command_line = '" + command_line + "'")
 
 
+"""
+RActionUploader: upload research action logs (pixel/custom with action_id).
+Reads side-copy inbox RActionClickhouse only — never deletes Predictor ResearchAction.
+"""
+class RActionUploader(object) :
+  clickhouse_conn : str
+  command_line_templ : jinja2.Template
+  logger = None
+
+  def __init__(self, config, logger = None) :
+    self.clickhouse_conn = config.clickhouse_conn
+    self.command_line_templ = jinja2.Template(
+      "RActionClickhouseAdapter.py {{ process_files|join(' ') }} | "
+      "clickhouse-client {{clickhouse_conn}} "
+      '--query="INSERT INTO RAction FORMAT CSVWithNames"')
+    self.logger = logger
+
+  def process(self, process_files) :
+    command_line = self.command_line_templ.render({
+      'clickhouse_conn' : self.clickhouse_conn,
+      'process_files' : process_files
+    })
+    try :
+      self.logger.debug("To upload " + " ".join(process_files))
+      ret_code = os.system(command_line)
+      self.logger.debug("From upload " + " ".join(process_files) + ": " + str(ret_code))
+      if ret_code == 0 :
+        for process_file in process_files:
+          os.unlink(process_file)
+      else :
+        raise Exception(
+          "Error on upload " + " ".join(process_files) +
+          ": command_line = '" + command_line + "'")
+    except Exception as e :
+      self.logger.exception(
+        "Exception on upload " + " ".join(process_files) + ": " +
+        str(e) + ", command_line = '" + command_line + "'")
+      raise
+
+
 def check_stat_files(
     interrupter,
     config = None,
@@ -231,6 +271,7 @@ def main() :
   processors = {}
   processors['RImpression'] = RImpressionUploader(config, logger = logger)
   processors['RClick'] = RClickUploader(config, logger = logger)
+  processors['RAction'] = RActionUploader(config, logger = logger)
 
   with SignalInterruptHandler(
     [ signal.SIGINT, signal.SIGUSR1, signal.SIGHUP ],

--- a/bin/validate_raction_clickhouse_pr.py
+++ b/bin/validate_raction_clickhouse_pr.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Local validation for feat/raction-clickhouse (no C++ build required)."""
+from __future__ import annotations
+
+import csv
+import io
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import textwrap
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+failures: list[str] = []
+
+
+def ok(msg: str) -> None:
+  print(f'OK  {msg}')
+
+
+def fail(msg: str) -> None:
+  failures.append(msg)
+  print(f'FAIL {msg}')
+
+
+def main() -> int:
+  for rel in [
+    'bin/RActionClickhouseAdapter.py',
+    'bin/RImpressionStatUploader.py',
+  ]:
+    r = subprocess.run(
+      [sys.executable, '-m', 'py_compile', str(ROOT / rel)],
+      capture_output=True, text=True)
+    (ok if r.returncode == 0 else fail)(
+      f'py_compile {rel}' + (f': {r.stderr.strip()}' if r.returncode else ''))
+
+  sh = ROOT / 'CMS/Plugin/exec/synclogs_rsync_side_copy.sh'
+  r = subprocess.run(['bash', '-n', str(sh)], capture_output=True, text=True)
+  (ok if r.returncode == 0 else fail)('bash -n synclogs_rsync_side_copy.sh')
+
+  for rel in [
+    'CMS/Plugin/xslt/LogProcessing/SyncLogs.xsl',
+    'CMS/Plugin/xslt/LogProcessing/ClickhouseUploader.xsl',
+  ]:
+    r = subprocess.run(['xmllint', '--noout', str(ROOT / rel)], capture_output=True, text=True)
+    (ok if r.returncode == 0 else fail)(f'xmllint {rel}')
+
+  sync = (ROOT / 'CMS/Plugin/xslt/LogProcessing/SyncLogs.xsl').read_text()
+  if sync.count('RequestInfoManager/Out/ResearchAction/RAction_*') == 1 and 'RActionClickhouse' in sync:
+    ok('SyncLogs RAction side-copy once')
+  else:
+    fail('SyncLogs RAction wiring unexpected')
+
+  chxsl = (ROOT / 'CMS/Plugin/xslt/LogProcessing/ClickhouseUploader.xsl').read_text()
+  if 'RActionClickhouse' in chxsl:
+    ok('ClickhouseUploader watches RActionClickhouse')
+  else:
+    fail('ClickhouseUploader missing RActionClickhouse')
+
+  sample = textwrap.dedent('''\
+    Timestamp,Device,IP Address,UID,URL,Action ID,Order ID,Order Value
+    2026-08-03 08:07:07,12700029,95.24.37.71,uid1,https://hoff.ru/,9457,,0.0
+    2026-08-03_09:00:00,@1,@1.2.3.4,-,@https://x/,@100,@ord,1.5
+    ''')
+  with tempfile.TemporaryDirectory() as td:
+    f = Path(td) / 'RAction_test.csv'
+    f.write_text(sample)
+    r = subprocess.run(
+      [sys.executable, str(ROOT / 'bin/RActionClickhouseAdapter.py'), str(f)],
+      capture_output=True, text=True)
+    if r.returncode != 0:
+      fail(f'adapter: {r.stderr}')
+    else:
+      rows = list(csv.reader(io.StringIO(r.stdout)))
+      if rows[0][0] != 'time' or rows[1][5] != '9457' or rows[2][4] != 'https://x/':
+        fail(f'adapter output unexpected: {rows}')
+      else:
+        ok('RAction adapter CSV')
+
+  patterns = {n: re.compile(rf'android {n}([._;]|$)', re.I) for n in range(8, 17)}
+  cases = [
+    (8, 'mozilla/5.0 (linux; android 8.0.0; sm)', True),
+    (8, 'mozilla/5.0 (linux; android 8.1.0; sm)', True),
+    (8, 'mozilla/5.0 (linux; android 8; sm)', True),
+    (8, 'mozilla/5.0 (linux; android 18.0; sm)', False),
+    (8, 'mozilla/5.0 (linux; android 80; sm)', False),
+    (10, 'mozilla/5.0 (linux; android 10; pixel)', True),
+    (10, 'mozilla/5.0 (linux; android 10.0.0; pixel)', True),
+    (16, 'mozilla/5.0 (linux; android 16; x)', True),
+  ]
+  for major, ua, expect in cases:
+    got = bool(patterns[major].search(ua.lower()))
+    (ok if got == expect else fail)(
+      f'regex android{major} expect={expect} ua={ua!r}')
+
+  fix = (ROOT / 'docs/sql/2026-08-03_fix_android_osversion_regexp.sql').read_text()
+  set_lines = [ln for ln in fix.splitlines() if 'SET match_regexp' in ln]
+  if len(set_lines) >= 9 and all("([._;]|$)" in ln and '\\' not in ln.split('=', 1)[-1] for ln in set_lines):
+    ok('fix SQL pattern android N([._;]|$)')
+  else:
+    fail(f'fix SQL pattern mismatch: {set_lines[:2]}')
+
+  with tempfile.TemporaryDirectory() as td:
+    td_path = Path(td)
+    src = td_path / 'RAction_x.csv'
+    src.write_text('a\n')
+    (td_path / 'ResearchAction').mkdir()
+    (td_path / 'RActionClickhouse').mkdir()
+    r = subprocess.run(
+      [str(sh), str(src),
+       str(td_path / 'ResearchAction') + '/',
+       str(td_path / 'RActionClickhouse') + '/'],
+      capture_output=True, text=True)
+    if r.returncode == 0 and (td_path / 'ResearchAction' / 'RAction_x.csv').exists() \
+        and (td_path / 'RActionClickhouse' / 'RAction_x.csv').exists():
+      ok('side_copy dual rsync')
+    else:
+      fail(f'side_copy failed: {r.returncode} {r.stderr}')
+
+  print(f'\nSUMMARY passed_checks_failed={len(failures)}')
+  for item in failures:
+    print(' -', item)
+  return 1 if failures else 0
+
+
+if __name__ == '__main__':
+  # allow running from repo root: python3 docs/... or bin
+  sys.exit(main())

--- a/docs/RAction_ClickHouse_DEPLOY.md
+++ b/docs/RAction_ClickHouse_DEPLOY.md
@@ -1,0 +1,66 @@
+# RAction → ClickHouse + Android OSVERSION regex fix
+
+## Why this replaces AdvertiserAction dual-copy (PR #46)
+
+Critical re-check of the pipeline:
+
+1. `RequestLogLoader` sends AdvertiserAction **with `action_id`** via `process_custom_action(AdvExActionInfo)`.
+2. `ResearchActionLogger::process_custom_action` already writes **`RAction`** CSV (`UID`, `Action ID`, `URL`/referrer, order…).
+3. `process_adv_action` is only used when `action_id` is absent (minimal `AdvActionInfo`) — not the normal `/conv?convid=…` path.
+
+So pixel hits with `convid` already land in **RAction**. Pulling raw `AdvertiserAction` from FE/CM hosts was unnecessary SyncLogs complexity.
+
+This change:
+
+- Side-copies **RAction** from RIM → Predictor `ResearchAction` (unchanged for PredictorMerger) **and** `RActionClickhouse` (CH inbox).
+- ClickhouseUploader consumes **only** `RActionClickhouse` and deletes after successful INSERT (does not touch Predictor’s `ResearchAction` backlog).
+- Fixes Android OSVERSION regexes (broken double-escaped `\\s`).
+
+## Files
+
+| Path | Change |
+|---|---|
+| `RequestInfoSvcs/.../RequestOutLogger.cpp` | Comment why `process_adv_action` stays empty |
+| `CMS/Plugin/xslt/.../SyncLogs.xsl` | RAction dedicated FeedRouteGroup + side-copy |
+| `CMS/Plugin/exec/synclogs_rsync_side_copy.sh` | primary OK / side best-effort |
+| `CMS/Plugin/exec/DACSConf.sh` | install helper script |
+| `CMS/Plugin/xslt/.../ClickhouseUploader.xsl` | watch `RActionClickhouse` |
+| `bin/RActionClickhouseAdapter.py` | RAction CSV → CH |
+| `bin/RImpressionStatUploader.py` | `RAction` processor |
+| `DACS/.../SyncLogsServer.pm` | mkdir inbox |
+| `DACS/.../ClickhouseUploader.pm` | mkdir inbox |
+| `docs/sql/2026-08-03_raction_clickhouse.sql` | CH DDL |
+| `docs/sql/2026-08-03_fix_android_osversion_regexp.sql` | Android regex fix |
+
+## Deploy (minimal)
+
+1. `clickhouse-client -h click00 --multiquery < docs/sql/2026-08-03_raction_clickhouse.sql`
+2. On Postgres `stat`: run `docs/sql/2026-08-03_fix_android_osversion_regexp.sql`  
+   Verify: `match_regexp` is exactly `android N[._]` (no double backslash before `s`).
+3. Regenerate CMS configs; ensure `synclogs_rsync_side_copy.sh` next to `copy_and_backup.sh`.
+4. Restart ClickhouseUploader (adbe00), then SyncLogs on RIM hosts.
+5. Check `…/RActionClickhouse` files appear and disappear; `SELECT count() FROM RAction WHERE time > now() - 1 HOUR`.
+6. Confirm `…/ResearchAction` still receives files (Predictor path).
+
+### Android regex check (before COMMIT)
+
+```sql
+SELECT p.name, pd.match_regexp,
+       position('\' in pd.match_regexp) AS first_bs
+FROM platformdetector pd
+JOIN platform p ON p.platform_id = pd.platform_id
+WHERE p.name = 'Android 8';
+```
+
+After fix: `match_regexp = android 8[._]`, `first_bs = 0`.
+
+## Known limits
+
+- `URL` in RAction is **page referrer**, not full `/conv?...` query string.
+- RAction side-copy group does not re-implement predictor `auxiliaryRef` / backup chain (primary still lands on main predictor `ResearchAction`).
+- Historical `ResearchAction` backlog on adbe00 is **not** auto-uploaded (inbox starts empty for new files only). Clean backlog separately if needed.
+- Actions **without** `action_id` still do not appear in RAction (by design of RequestLogLoader).
+
+## Rollback
+
+Revert SyncLogs / ClickhouseUploader configs and restart services. Android SQL can be reverted to previous patterns if required (not recommended).

--- a/docs/RAction_ClickHouse_DEPLOY.md
+++ b/docs/RAction_ClickHouse_DEPLOY.md
@@ -31,28 +31,30 @@ This change:
 | `DACS/.../ClickhouseUploader.pm` | mkdir inbox |
 | `docs/sql/2026-08-03_raction_clickhouse.sql` | CH DDL |
 | `docs/sql/2026-08-03_fix_android_osversion_regexp.sql` | Android regex fix |
+| `bin/validate_raction_clickhouse_pr.py` | local smoke checks (adapter/xsl/regex/side-copy) |
 
 ## Deploy (minimal)
 
 1. `clickhouse-client -h click00 --multiquery < docs/sql/2026-08-03_raction_clickhouse.sql`
 2. On Postgres `stat`: run `docs/sql/2026-08-03_fix_android_osversion_regexp.sql`  
-   Verify: `match_regexp` is exactly `android N[._]` (no double backslash before `s`).
+   Verify: `match_regexp` is exactly `android N([._;]|$)` and contains **no** `\`.
 3. Regenerate CMS configs; ensure `synclogs_rsync_side_copy.sh` next to `copy_and_backup.sh`.
 4. Restart ClickhouseUploader (adbe00), then SyncLogs on RIM hosts.
 5. Check `…/RActionClickhouse` files appear and disappear; `SELECT count() FROM RAction WHERE time > now() - 1 HOUR`.
 6. Confirm `…/ResearchAction` still receives files (Predictor path).
+7. Optional local checks (no C++ build): `python3 bin/validate_raction_clickhouse_pr.py`
 
 ### Android regex check (before COMMIT)
 
 ```sql
 SELECT p.name, pd.match_regexp,
-       position('\' in pd.match_regexp) AS first_bs
+       position(E'\\' IN pd.match_regexp) AS first_bs
 FROM platformdetector pd
 JOIN platform p ON p.platform_id = pd.platform_id
 WHERE p.name = 'Android 8';
 ```
 
-After fix: `match_regexp = android 8[._]`, `first_bs = 0`.
+After fix: `match_regexp = android 8([._;]|$)`, `first_bs = 0`.
 
 ## Known limits
 

--- a/docs/sql/2026-08-03_fix_android_osversion_regexp.sql
+++ b/docs/sql/2026-08-03_fix_android_osversion_regexp.sql
@@ -1,0 +1,64 @@
+-- Fix OSVERSION Android detectors.
+-- Broken form in DB (bytes): android N([.\\s_;]|$)  -- \\s is NOT whitespace
+-- New form (no backslashes):  android N([._]|$)
+-- Matches real UA: android 8.0.0 / 8.1.0 / android 10; also bare "android 8".
+-- Aligned with iOS style (os 15[._]) but keeps end-anchor for bare majors.
+--
+-- PG 9.4. Verify AFTER update: match_regexp must contain zero '\' characters.
+
+BEGIN;
+
+UPDATE public.platformdetector pd
+SET match_regexp = 'android 8([._]|$)', last_updated = now()
+FROM public.platform p
+WHERE pd.platform_id = p.platform_id AND p.type = 'OSVERSION' AND p.name = 'Android 8';
+
+UPDATE public.platformdetector pd
+SET match_regexp = 'android 9([._]|$)', last_updated = now()
+FROM public.platform p
+WHERE pd.platform_id = p.platform_id AND p.type = 'OSVERSION' AND p.name = 'Android 9';
+
+UPDATE public.platformdetector pd
+SET match_regexp = 'android 10([._]|$)', last_updated = now()
+FROM public.platform p
+WHERE pd.platform_id = p.platform_id AND p.type = 'OSVERSION' AND p.name = 'Android 10';
+
+UPDATE public.platformdetector pd
+SET match_regexp = 'android 11([._]|$)', last_updated = now()
+FROM public.platform p
+WHERE pd.platform_id = p.platform_id AND p.type = 'OSVERSION' AND p.name = 'Android 11';
+
+UPDATE public.platformdetector pd
+SET match_regexp = 'android 12([._]|$)', last_updated = now()
+FROM public.platform p
+WHERE pd.platform_id = p.platform_id AND p.type = 'OSVERSION' AND p.name = 'Android 12';
+
+UPDATE public.platformdetector pd
+SET match_regexp = 'android 13([._]|$)', last_updated = now()
+FROM public.platform p
+WHERE pd.platform_id = p.platform_id AND p.type = 'OSVERSION' AND p.name = 'Android 13';
+
+UPDATE public.platformdetector pd
+SET match_regexp = 'android 14([._]|$)', last_updated = now()
+FROM public.platform p
+WHERE pd.platform_id = p.platform_id AND p.type = 'OSVERSION' AND p.name = 'Android 14';
+
+UPDATE public.platformdetector pd
+SET match_regexp = 'android 15([._]|$)', last_updated = now()
+FROM public.platform p
+WHERE pd.platform_id = p.platform_id AND p.type = 'OSVERSION' AND p.name = 'Android 15';
+
+UPDATE public.platformdetector pd
+SET match_regexp = 'android 16([._]|$)', last_updated = now()
+FROM public.platform p
+WHERE pd.platform_id = p.platform_id AND p.type = 'OSVERSION' AND p.name = 'Android 16';
+
+SELECT p.name, pd.match_regexp,
+       length(pd.match_regexp) AS len,
+       position(E'\\' IN pd.match_regexp) AS first_backslash_pos
+FROM public.platformdetector pd
+JOIN public.platform p ON p.platform_id = pd.platform_id
+WHERE p.type = 'OSVERSION' AND p.name ~ '^Android [0-9]'
+ORDER BY p.name;
+
+COMMIT;

--- a/docs/sql/2026-08-03_fix_android_osversion_regexp.sql
+++ b/docs/sql/2026-08-03_fix_android_osversion_regexp.sql
@@ -1,55 +1,59 @@
 -- Fix OSVERSION Android detectors.
--- Broken form in DB (bytes): android N([.\\s_;]|$)  -- \\s is NOT whitespace
--- New form (no backslashes):  android N([._]|$)
--- Matches real UA: android 8.0.0 / 8.1.0 / android 10; also bare "android 8".
--- Aligned with iOS style (os 15[._]) but keeps end-anchor for bare majors.
+-- Broken form in DB (bytes): android N([.\\s_;]|$)
+--   \\s became literal '\' + 's', NOT whitespace.
+-- New form (no backslashes): android N([._;]|$)
+--   '.'  -> Android 8.0.0 / 8.1.0
+--   '_'  -> rare underscore forms
+--   ';'  -> typical UA "Android 10; Pixel"
+--   '$'  -> bare major at end
+-- Does NOT match Android 18 / 80.
 --
--- PG 9.4. Verify AFTER update: match_regexp must contain zero '\' characters.
+-- PG 9.4. After UPDATE: position(E'\\' IN match_regexp) must be 0.
 
 BEGIN;
 
 UPDATE public.platformdetector pd
-SET match_regexp = 'android 8([._]|$)', last_updated = now()
+SET match_regexp = 'android 8([._;]|$)', last_updated = now()
 FROM public.platform p
 WHERE pd.platform_id = p.platform_id AND p.type = 'OSVERSION' AND p.name = 'Android 8';
 
 UPDATE public.platformdetector pd
-SET match_regexp = 'android 9([._]|$)', last_updated = now()
+SET match_regexp = 'android 9([._;]|$)', last_updated = now()
 FROM public.platform p
 WHERE pd.platform_id = p.platform_id AND p.type = 'OSVERSION' AND p.name = 'Android 9';
 
 UPDATE public.platformdetector pd
-SET match_regexp = 'android 10([._]|$)', last_updated = now()
+SET match_regexp = 'android 10([._;]|$)', last_updated = now()
 FROM public.platform p
 WHERE pd.platform_id = p.platform_id AND p.type = 'OSVERSION' AND p.name = 'Android 10';
 
 UPDATE public.platformdetector pd
-SET match_regexp = 'android 11([._]|$)', last_updated = now()
+SET match_regexp = 'android 11([._;]|$)', last_updated = now()
 FROM public.platform p
 WHERE pd.platform_id = p.platform_id AND p.type = 'OSVERSION' AND p.name = 'Android 11';
 
 UPDATE public.platformdetector pd
-SET match_regexp = 'android 12([._]|$)', last_updated = now()
+SET match_regexp = 'android 12([._;]|$)', last_updated = now()
 FROM public.platform p
 WHERE pd.platform_id = p.platform_id AND p.type = 'OSVERSION' AND p.name = 'Android 12';
 
 UPDATE public.platformdetector pd
-SET match_regexp = 'android 13([._]|$)', last_updated = now()
+SET match_regexp = 'android 13([._;]|$)', last_updated = now()
 FROM public.platform p
 WHERE pd.platform_id = p.platform_id AND p.type = 'OSVERSION' AND p.name = 'Android 13';
 
 UPDATE public.platformdetector pd
-SET match_regexp = 'android 14([._]|$)', last_updated = now()
+SET match_regexp = 'android 14([._;]|$)', last_updated = now()
 FROM public.platform p
 WHERE pd.platform_id = p.platform_id AND p.type = 'OSVERSION' AND p.name = 'Android 14';
 
 UPDATE public.platformdetector pd
-SET match_regexp = 'android 15([._]|$)', last_updated = now()
+SET match_regexp = 'android 15([._;]|$)', last_updated = now()
 FROM public.platform p
 WHERE pd.platform_id = p.platform_id AND p.type = 'OSVERSION' AND p.name = 'Android 15';
 
 UPDATE public.platformdetector pd
-SET match_regexp = 'android 16([._]|$)', last_updated = now()
+SET match_regexp = 'android 16([._;]|$)', last_updated = now()
 FROM public.platform p
 WHERE pd.platform_id = p.platform_id AND p.type = 'OSVERSION' AND p.name = 'Android 16';
 

--- a/docs/sql/2026-08-03_raction_clickhouse.sql
+++ b/docs/sql/2026-08-03_raction_clickhouse.sql
@@ -1,0 +1,20 @@
+-- ClickHouse table for research RAction (pixel / custom actions with action_id).
+-- Source: RequestInfoManager ResearchAction → side-copy inbox RActionClickhouse.
+-- Columns mirror ResearchActionTraits::csv_header().
+
+CREATE TABLE IF NOT EXISTS default.RAction
+(
+    `time` DateTime('UTC'),
+    `device_channel_id` UInt64,
+    `ip` String,
+    `user_id` String,
+    `referrer` String,
+    `action_id` UInt64,
+    `order_id` String,
+    `cur_value` Float64
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(time)
+ORDER BY (action_id, time, user_id)
+TTL time + toIntervalDay(180)
+SETTINGS index_granularity = 8192;


### PR DESCRIPTION
## Summary
Addresses review of the previous AdvertiserAction approach and Android detector regexes.

### ClickHouse / pixels
- **Do not** dual-copy `AdvertiserAction` from FE/CM hosts.
- Normal `/conv?convid=…` already reaches `ResearchActionLogger` via `process_custom_action` when `action_id` is set (`RequestLogLoader`).
- Side-copy **RAction** to `RActionClickhouse` for ClickhouseUploader; keep `ResearchAction` for Predictor (uploader never deletes Predictor inbox).
- Document why `process_adv_action` stays empty (no `action_id` → insufficient fields for RAction CSV).

### Android OSVERSION
- Replace broken `android N([.\\s_;]|$)` (double-escaped `\\s` → literal `\`+`s`, not whitespace).
- New pattern: `android N([._]|$)` — no backslashes; matches `8.0.0` / `8.1.0` / bare major; does not match `18` / `80`.

## Test plan
- [ ] Apply `docs/sql/2026-08-03_raction_clickhouse.sql` on click00
- [ ] Apply `docs/sql/2026-08-03_fix_android_osversion_regexp.sql` on Postgres; confirm `position(E'\\' IN match_regexp)=0`
- [ ] Regen CMS configs; `synclogs_rsync_side_copy.sh` installed
- [ ] Restart ClickhouseUploader, then SyncLogs on RIM hosts
- [ ] New files in `RActionClickhouse` upload and disappear; `ResearchAction` still grows for Predictor
- [ ] `SELECT count() FROM RAction WHERE time > now() - INTERVAL 1 HOUR`
- [ ] Spot-check UA match for Android 8/10/16 after CampaignServer reload

See `docs/RAction_ClickHouse_DEPLOY.md`.

Supersedes #46.

Made with [Cursor](https://cursor.com)